### PR TITLE
update rm-empty-targets.py

### DIFF
--- a/rm-empty-targets/README.md
+++ b/rm-empty-targets/README.md
@@ -21,4 +21,16 @@ The algorithm used by this example is as follows:
 ```
 
 The script outputs a list of the org/targets that were deleted (or
-would have been deleted, if using `--dry-run`) to `stdout`, one per line.
+would have been deleted, if omitting `--delete` flag) to `stdout`, one per line.
+
+Example use:
+
+dry-run:
+```bash
+python3 rm-empty-targets.py $SNYK_GROUP_ID
+```
+
+actual deleting:
+```bash
+python3 rm-empty-targets.py $SNYK_GROUP_ID --delete
+```


### PR DESCRIPTION
Update rm-empty-targets to use REST API exclusively, fix count of deleted targets, include use examples in README.md