### PR TITLE
Improve error handling for GET call to /groups API

### DIFF
--- a/project-collections/README.md
+++ b/project-collections/README.md
@@ -55,3 +55,7 @@ remove_collection -a \<snyk-auth-token\> -g "kevin.matthews Group" -o "PR Test O
 - --effective_severity_level "Comma separated list of severities to be identified in tagged project issues payload"
 - --api_ver "The version of the Snyk API to be used (default recommended)"
 
+### Note 
+Some of the APIs used are in beta. Others are GA. As the beta's become GA, I will remove the 'hard-coded' use of their 
+beta counterparts. Meantime, please DO NOT specify a beta version of an API should you wish to choose a specific 
+version. It is recommended at this time that you allow the default version to be used.

--- a/project-collections/utils/util_func.py
+++ b/project-collections/utils/util_func.py
@@ -21,28 +21,32 @@ def process_collection(headers, args, func):
     # Retrieve all my groups
     g_response = json.loads(utils.rest_api.groups(headers, args["api_ver"]))
 
-    # Iterate to the named group
-    for group in g_response['data']:
-        if group['attributes']['name'] == args['grp_name']:
-            go_pagination = None
-            while True:
-                go_response = json.loads(utils.rest_api.group_orgs(headers, args["api_ver"], group, go_pagination))
+    try:
+        # Iterate to the named group
+        for group in g_response['data']:
+            if group['attributes']['name'] == args['grp_name']:
+                go_pagination = None
+                while True:
+                    go_response = json.loads(utils.rest_api.group_orgs(headers, args["api_ver"], group, go_pagination))
 
-                # Iterate to the named Org
-                for org in go_response['data']:
-                    if org['attributes']['name'] == args["org_name"]:
+                    # Iterate to the named Org
+                    for org in go_response['data']:
+                        if org['attributes']['name'] == args["org_name"]:
 
-                        # Find the collection id
-                        collection_id = find_collection(headers, args, org)
+                            # Find the collection id
+                            collection_id = find_collection(headers, args, org)
 
-                        # Do the collection process within the passed function
-                        func(headers, args, org, collection_id)
+                            # Do the collection process within the passed function
+                            func(headers, args, org, collection_id)
 
-                # Next page?
-                go_pagination = next_page(go_response)
-                if go_pagination is None:
-                    break
-
+                    # Next page?
+                    go_pagination = next_page(go_response)
+                    if go_pagination is None:
+                        break
+    except Exception:
+        print("GET call to /groups API returned no 'data'")
+        print(json.dumps(g_response, indent=4))
+        return
 
 
 def find_collection(headers, args, org):


### PR DESCRIPTION
Customer reported an error when running the script. Debugging has concluded that either the auth token is incorrect or the version of the API specified does not support the /groups API. Error handling displays the formatted json error message.